### PR TITLE
Fixed socket not connected issue

### DIFF
--- a/ClientExample/Program.cs
+++ b/ClientExample/Program.cs
@@ -15,7 +15,7 @@ namespace ClientExample
                 ServerConnection advertConnection = new ServerConnection();
 
                 // Connect
-                advertConnection.Connect("127.0.0.1", 9423);
+                advertConnection.Connect("127.0.0.1", 9423).AsyncWaitHandle.WaitOne();
 
                 // Create server data
                 Dictionary<string, object> data = new Dictionary<string, object>

--- a/MLAPI.ServerList.Client/ServerConnection.cs
+++ b/MLAPI.ServerList.Client/ServerConnection.cs
@@ -55,9 +55,9 @@ namespace MLAPI.ServerList.Client
             }
         }
 
-        public void Connect(string host, int port)
+        public IAsyncResult Connect(string host, int port)
         {
-            client.BeginConnect(host, port, (args) =>
+            return client.BeginConnect(host, port, (args) =>
             {
                 client.EndConnect(args);
 


### PR DESCRIPTION
Fix for SocketException on calling StartAdvertisment in ClientExample.

Issue:
> SocketException: A request to send or receive data was disallowed because the socket is not connected and (when sending on a datagram socket using a sendto call) no address was supplied.

Happens when connecting to remote address.