### PR TITLE
Fixed null issue on server receiving empty query

### DIFF
--- a/MLAPI.ServerList.Server/QueryParser.cs
+++ b/MLAPI.ServerList.Server/QueryParser.cs
@@ -884,7 +884,7 @@ namespace MLAPI.ServerList.Server
                 }
             }
 
-            return null;
+            return Builders<ServerModel>.Filter.Empty;
         }
     }
 }


### PR DESCRIPTION
Receiving an empty query on a server with MongoDB running causes null exception on line:
https://github.com/MidLevel/MLAPI.ServerList/blob/527500f01c60b1d197765e49d32bbaa16142208d/MLAPI.ServerList.Server/Program.cs#L425
> System.NullReferenceException
  HResult=0x80004003
  Message=Object reference not set to an instance of an object.
  Source=MongoDB.Driver
  StackTrace:
   at MongoDB.Driver.AndFilterDefinition1.Render(IBsonSerializer1 documentSerializer, IBsonSerializerRegistry serializerRegistry)